### PR TITLE
Pull Request: Updating of links to Isomer Ticket page

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -45,5 +45,10 @@ links:
         url: /partner-with-us/
       - title: Download Prospectus
         url: https://forms.monday.com/forms/4ae0e80795707021ca480047c3a90d66?r=use1
-  - title: TICKETS
-    url: /register
+  - title: GET YOUR PASS
+    url: https://2023.switchsg.org/qA08l?RefId=Isomer
+    sublinks:
+      - title: Ticket Info
+        url: /register
+      - title: Register for SWITCH 2023
+        url: https://2023.switchsg.org/qA08l?RefId=Isomer

--- a/index.md
+++ b/index.md
@@ -20,7 +20,7 @@ sections:
       background: /images/Homepage
         Images/switch2023_keyvisual_final_29mar_1200x450px-08.png
       button: REGISTER FOR SWITCH 2023!
-      url: /register
+      url: https://2023.switchsg.org/qA08l?RefId=Isomer
       key_highlights:
         - title: SWITCH Beyond
           description: Innovation & Technology Trends


### PR DESCRIPTION
Changes made:

1. Updated homepage button to point to Cvent ticket page vs. Isomer ticket info page (previous)
2. Updated Nav bar TICKET to "GET YOUR PASS" with added links for direct access to Cvent ticket page.